### PR TITLE
Add double quotes around variable test

### DIFF
--- a/script/docker-murmur
+++ b/script/docker-murmur
@@ -6,7 +6,7 @@ ICEFILE="/etc/murmur/ice.ini"
 WELCOMEFILE="/data/welcome.txt"
 
 setVal() {
-    if [ ${1} ] && [ ${2} ]; then
+    if [ ${1} ] && [ "${2}" ]; then
         echo "update setting: ${1} with: ${2}"
         sed -i -E 's;#?('"${1}"'=).*;\1'"${2}"';' "${CONFIGFILE}"
     fi


### PR DESCRIPTION
When setting an environment variable with whitespace (MURMUR_ICE=tcp -h 0.0.0.0 -p 6502 for example), sh will error out. Adding quotes around the ${2} variable fixes this issue.